### PR TITLE
fix paasify module source line in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Take this example:
 
 ```
 module "paasify" {
-  source = "github.com/nthomson-pivotal/pcf-paasify/terraform/aws?ref=2.6"
+  source = "github.com/nthomson-pivotal/pcf-paasify//terraform/aws?ref=2.6"
 
   env_name     = "paasify-test"
   dns_suffix   = "aws.paasify.org"
@@ -85,7 +85,7 @@ The following example Terraform configuration imports Paasify as a module target
 
 ```
 module "paasify" {
-  source = "github.com/nthomson-pivotal/pcf-paasify/terraform/aws"
+  source = "github.com/nthomson-pivotal/pcf-paasify//terraform/aws"
 
   env_name     = "test-env"
   dns_suffix   = "aws.paasify.org"


### PR DESCRIPTION
As per https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories
If a terraform module lives in a subdir of a remote git repo then it needs to have a double `//` to separate the repo from the subdir.

eg:  `github.com/nthomson-pivotal/pcf-paasify.git//terraform/aws?ref=2.6`
